### PR TITLE
getX: getX를 이용한 상태관리 

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:get/get.dart';
 import 'package:smallscaleflutterproject/ui_challenge/screen/card_list_screen.dart';
 import 'package:smallscaleflutterproject/pomodoro/screen/pomodoro_screen.dart';
+import 'package:smallscaleflutterproject/webtoon/screen/webtoon_detail_screen.dart';
 import 'package:smallscaleflutterproject/webtoon/screen/webtoon_list_screen.dart';
 
 void main() {
@@ -10,10 +12,11 @@ void main() {
 class MyApp extends StatelessWidget {
   const MyApp({Key? key}) : super(key: key);
 
-  // This widget is the root of your application.
+
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
+    return GetMaterialApp(
+      initialRoute: '/',
       title: 'Flutter Demo',
       theme: ThemeData(
         primarySwatch: Colors.blue,
@@ -25,11 +28,12 @@ class MyApp extends StatelessWidget {
         ),
         cardColor: Colors.white,
       ),
-      routes: {
-        '/cardList': (context) => CardListScreen(),
-        '/pomodoro': (context) => PomodoroScreen(),
-        '/webtoon': (context) => WebtoonListScreen(),
-      },
+      getPages: [
+        GetPage(name: '/cardList', page: () => CardListScreen()),
+        GetPage(name: '/pomodoro', page: () => PomodoroScreen()),
+        GetPage(name: '/webtoon', page: () => WebtoonListScreen()),
+        GetPage(name: '/webtoonDetail', page: () => WebtoonDetailScreen()),
+      ],
       debugShowCheckedModeBanner: false,
       home: const MyHomePage(title: 'Flutter Demo Home Page'),
     );
@@ -46,13 +50,6 @@ class MyHomePage extends StatefulWidget {
 }
 
 class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
-
-  void _incrementCounter() {
-    setState(() {
-      _counter++;
-    });
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -63,19 +60,19 @@ class _MyHomePageState extends State<MyHomePage> {
         children: [
           TextButton(
             onPressed: () {
-              Navigator.pushNamed(context, '/cardList');
+              Get.toNamed('/cardList');
             },
             child: Text('UI CHALLENGE'),
           ),
           TextButton(
             onPressed: () {
-              Navigator.pushNamed(context, '/pomodoro');
+              Get.toNamed('/pomodoro');
             },
             child: Text('POMODORO'),
           ),
           TextButton(
             onPressed: () {
-              Navigator.pushNamed(context, '/webtoon');
+              Get.toNamed('/webtoon');
             },
             child: Text('WEBTOON'),
           ),

--- a/lib/webtoon/screen/webtoon_detail_screen.dart
+++ b/lib/webtoon/screen/webtoon_detail_screen.dart
@@ -1,12 +1,13 @@
 import 'package:flutter/material.dart';
+import 'package:get/get.dart';
 import 'package:smallscaleflutterproject/webtoon/models/webtoon_model.dart';
 
 class WebtoonDetailScreen extends StatelessWidget {
-  final WebtoonModel webtoon;
+
+  final WebtoonModel webtoon = Get.arguments as WebtoonModel;
 
   WebtoonDetailScreen({
     Key? key,
-    required this.webtoon,
   }) : super(key: key);
 
   @override
@@ -16,8 +17,8 @@ class WebtoonDetailScreen extends StatelessWidget {
         backgroundColor: Colors.white,
         foregroundColor: Colors.green,
         title: Text(
-          '${webtoon.title}',
-          style: TextStyle(
+          webtoon.title,
+          style: const TextStyle(
             fontSize: 22,
             fontWeight: FontWeight.w400,
           ),
@@ -26,7 +27,7 @@ class WebtoonDetailScreen extends StatelessWidget {
       ),
       body: Column(
         children: [
-          SizedBox(height: 50),
+          const SizedBox(height: 50),
           Row(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [

--- a/lib/webtoon/screen/webtoon_list_screen.dart
+++ b/lib/webtoon/screen/webtoon_list_screen.dart
@@ -1,8 +1,7 @@
 import 'dart:core';
 import 'package:flutter/material.dart';
-import 'package:flutter/src/painting/box_shadow.dart';
+import 'package:get/get.dart';
 import 'package:smallscaleflutterproject/webtoon/services/api_service.dart';
-import 'package:smallscaleflutterproject/webtoon/models/webtoon_model.dart';
 import 'package:smallscaleflutterproject/webtoon/widget/webtoon_card_widget.dart';
 
 class WebtoonListScreen extends StatelessWidget {
@@ -11,7 +10,7 @@ class WebtoonListScreen extends StatelessWidget {
   /// statefulWidget을 상속 받아 setState() 해주기보다
   /// statelessWidget을 상속 받아 FutureBuilder widget으로 데이터를 받아오는 것이 일반화
 
-  final Future<List<WebtoonModel>> _webtoonList = ApiService.getTodaysToons();
+  final apiService = Get.put(ApiService());  /// [Get.put()] 을 통해 [ApiService]를 등록
 
   /// 1. StatefulWidget을 상속받는 경우, setState를 통해 webtoonsList load
   // void _waitForWebtoons() {
@@ -26,39 +25,41 @@ class WebtoonListScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: Colors.white,
-      appBar: AppBar(
-        backgroundColor: Colors.white,
-        foregroundColor: Colors.green,
-        title: const Text(
-          'Webtoons',
-          style: TextStyle(
-            fontSize: 22,
-            fontWeight: FontWeight.w400,
+    return GetX<ApiService>(
+      builder: (context) {
+        return Scaffold(
+          backgroundColor: Colors.white,
+          appBar: AppBar(
+            backgroundColor: Colors.white,
+            foregroundColor: Colors.green,
+            title: const Text(
+              'Webtoons',
+              style: TextStyle(
+                fontSize: 22,
+                fontWeight: FontWeight.w400,
+              ),
+            ),
+            elevation: 0,
           ),
-        ),
-        elevation: 0,
-      ),
-      body: FutureBuilder(
-        future: _webtoonList,
-        builder: (context, AsyncSnapshot snapshot) {
-          print(snapshot.hasData);
-          if (snapshot.hasData) {
-            return Column(
-              children: [
-                SizedBox(height: 50),
-                Expanded( /// 남는 영역을 자식 widget으로 채움.
-                  child: _webtoonListWidget(snapshot.data!),
+          body: Column(
+            children: [
+              if (apiService.webtoonList.isNotEmpty) ...[
+                const SizedBox(height: 50),
+                Expanded(
+                  /// 남는 영역을 자식 widget으로 채움.
+                  child: _webtoonListWidget(apiService.webtoonList),
+                ),
+              ] else ...[
+                Container(
+                  padding: const EdgeInsets.symmetric(vertical: 30),
+                  alignment: Alignment.center,
+                  child: const CircularProgressIndicator(),
                 ),
               ],
-            );
-          };
-          return const Center(
-            child: CircularProgressIndicator(),
-          );
-        },
-      ),
+            ],
+          ),
+        );
+      }
     );
   }
 
@@ -68,7 +69,8 @@ class WebtoonListScreen extends StatelessWidget {
       itemCount: webtoonList.length,  /// [hasData]가 [true]일 경우에만 반환하므로 [null] 보증 (!)
       padding: const EdgeInsets.symmetric(horizontal: 15.0),
       itemBuilder: (context, index) {
-        var webtoon = webtoonList[index];
+        // var webtoon = webtoonList[index];
+        var webtoon = apiService.webtoonList[index];
         return WebtoonCardWidget(webtoon: webtoon);
       },
       separatorBuilder: (context, index) {

--- a/lib/webtoon/screen/webtoon_list_screen.dart
+++ b/lib/webtoon/screen/webtoon_list_screen.dart
@@ -66,7 +66,7 @@ class WebtoonListScreen extends StatelessWidget {
     return ListView.separated(
       scrollDirection: Axis.horizontal,
       itemCount: webtoonList.length,  /// [hasData]가 [true]일 경우에만 반환하므로 [null] 보증 (!)
-      padding: EdgeInsets.symmetric(horizontal: 15.0),
+      padding: const EdgeInsets.symmetric(horizontal: 15.0),
       itemBuilder: (context, index) {
         var webtoon = webtoonList[index];
         return WebtoonCardWidget(webtoon: webtoon);

--- a/lib/webtoon/services/api_service.dart
+++ b/lib/webtoon/services/api_service.dart
@@ -1,13 +1,42 @@
+import 'package:get/get.dart';
 import 'package:smallscaleflutterproject/webtoon/models/webtoon_model.dart';
 import 'package:http/http.dart' as http;
 import 'dart:convert';
 
-class ApiService {
+class ApiService extends GetxController {
 
   static const String baseUrl = 'https://webtoon-crawler.nomadcoders.workers.dev';
   static const String today = 'today';
 
-  static Future<List<WebtoonModel>> getTodaysToons() async {
+  final RxList<WebtoonModel> _webtoonList = <WebtoonModel>[].obs;
+
+  List<WebtoonModel> get webtoonList => _webtoonList;
+
+  /// [onInit]은 [GetxController]가 생성될 때, 자동으로 실행되는 함수
+  @override
+  void onInit() {
+    // TODO: implement onInit
+    super.onInit();
+
+    getTodaysToons();
+  }
+
+  /// [onReady]는 [GetxController]가 생성되고, [onInit]이 실행된 후에 실행되는 함수
+  @override
+  void onReady() {
+    // TODO: implement onReady
+    super.onReady();
+  }
+
+  /// [onClose]는 [GetxController]가 종료될 때, 자동으로 실행되는 함수
+  @override
+  void onClose() {
+    // TODO: implement onClose
+    super.onClose();
+  }
+
+  void getTodaysToons() async {
+    print('getTodaysToons');
     final url = Uri.parse('${baseUrl}/${today}');
     final response = await http.get(url);
 
@@ -19,7 +48,7 @@ class ApiService {
       for(dynamic webtoon in webtoons) {
         webtoonList.add(WebtoonModel.fromJson(webtoon));
       }
-      return webtoonList;
+      _webtoonList.addAll(webtoonList);
     }
     throw Error();  /// [statusCode]가 200이 아닌 경우에는 [error]를 던져줌.
   }

--- a/lib/webtoon/services/api_service.dart
+++ b/lib/webtoon/services/api_service.dart
@@ -15,7 +15,6 @@ class ApiService extends GetxController {
   /// [onInit]은 [GetxController]가 생성될 때, 자동으로 실행되는 함수
   @override
   void onInit() {
-    // TODO: implement onInit
     super.onInit();
 
     getTodaysToons();
@@ -24,14 +23,12 @@ class ApiService extends GetxController {
   /// [onReady]는 [GetxController]가 생성되고, [onInit]이 실행된 후에 실행되는 함수
   @override
   void onReady() {
-    // TODO: implement onReady
     super.onReady();
   }
 
   /// [onClose]는 [GetxController]가 종료될 때, 자동으로 실행되는 함수
   @override
   void onClose() {
-    // TODO: implement onClose
     super.onClose();
   }
 

--- a/lib/webtoon/widget/webtoon_card_widget.dart
+++ b/lib/webtoon/widget/webtoon_card_widget.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:get/get.dart';
 import 'package:smallscaleflutterproject/webtoon/models/webtoon_model.dart';
 import 'package:smallscaleflutterproject/webtoon/screen/webtoon_detail_screen.dart';
 
@@ -14,13 +15,7 @@ class WebtoonCardWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     return GestureDetector(
       onTap: () {
-        Navigator.push(
-          context,
-          MaterialPageRoute(
-            builder: (context) => WebtoonDetailScreen(webtoon: webtoon),
-            fullscreenDialog: true,
-          ),
-        );
+        Get.toNamed('/webtoonDetail', arguments: webtoon);
       },
       child: Column(
         children: [
@@ -48,12 +43,12 @@ class WebtoonCardWidget extends StatelessWidget {
               ),
             ),
           ),
-          SizedBox(
+          const SizedBox(
             height: 10,
           ),
           Text(
             webtoon.title,
-            style: TextStyle(
+            style: const TextStyle(
               fontSize: 18,
             ),
           ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,6 +36,7 @@ dependencies:
   cupertino_icons: ^1.0.2
   intl: ^0.18.0
   http: ^0.13.5
+  get: ^4.6.5
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
**[오늘의 배움]**

- getX 패키지 설치
- flutter에서 기본으로 제공하는 `Navigator` &rarr; getX 패키지 `routes`로 관리할 수 있게 변경
&rarr; 데이터 넘겨주는 방식은 여러가지가 있는데, 현재 `arguments`로 넘겨줌
- 반응형 컨트롤러 생성 
&rarr; 숫자를 저장할 변수를 `Rx`로 선언하고, `.obs` 붙여줌
&rarr; GetxController 상속 받았을 때, GetX lifeCycle를 이용할 수 있음